### PR TITLE
Update appVersion to v0.11.5 and add config for publicURL

### DIFF
--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 name: firefly
 description: A Helm chart for deploying FireFly and FireFly HTTPS Dataexchange onto Kubernetes.
 type: application
-appVersion: "0.11.4"
+appVersion: "0.11.5"
 version: "0.0.1"
 
 maintainers:

--- a/charts/firefly/templates/_helpers.tpl
+++ b/charts/firefly/templates/_helpers.tpl
@@ -138,10 +138,12 @@ debug:
 {{- end }}
 http:
   port: {{ .Values.core.service.httpPort }}
+  publicURL: {{ .Values.core.service.httpPublicURL }}
   address: 0.0.0.0
 admin:
   port:  {{ .Values.core.service.adminPort }}
   address: 0.0.0.0
+  publicURL: {{ .Values.core.service.adminPublicURL }}
   enabled: {{ .Values.config.adminEnabled }}
   preinit: {{ and .Values.config.adminEnabled .Values.config.preInit }}
 metrics:


### PR DESCRIPTION
- Upgrade to pick up latest FireFly release [v0.11.5](https://github.com/hyperledger/firefly/releases/tag/v0.11.5)
- Update to let you set `publicURL` so that if you are using an ingress to expose the Swagger, you can configure it to function correctly with the external hostname of your integress