### PR TITLE
Bump DX version

### DIFF
--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -19,7 +19,7 @@ name: firefly
 description: A Helm chart for deploying FireFly and FireFly HTTPS Dataexchange onto Kubernetes.
 type: application
 appVersion: "0.13.0"
-version: "0.3.0"
+version: "0.3.1"
 
 maintainers:
   - name: hfuss

--- a/charts/firefly/values.yaml
+++ b/charts/firefly/values.yaml
@@ -267,7 +267,7 @@ dataexchange:
   image:
     repository: ghcr.io/hyperledger/firefly-dataexchange-https
     pullPolicy: IfNotPresent
-    tag: v0.10.3
+    tag: v0.10.4
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
Latest FF release needs DX `v0.10.4` as mentioned here: https://github.com/hyperledger/firefly/releases/tag/v0.13.0. 