### PR TITLE
Updating DX Plugin Name

### DIFF
--- a/charts/firefly/templates/_helpers.tpl
+++ b/charts/firefly/templates/_helpers.tpl
@@ -290,14 +290,14 @@ dataexchange:
 {{- else }}
 dataexchange:
   {{- if .Values.dataexchange.enabled }}
-  https:
+  ffdx:
     url: http://{{ include "firefly.fullname" . }}-dx.{{ .Release.Namespace }}.svc:{{ .Values.dataexchange.service.apiPort }}
     {{- if .Values.dataexchange.apiKey }}
     headers:
       x-api-key: {{ .Values.dataexchange.apiKey | quote }}
     {{- end }}
   {{- else }}
-  https:
+  ffdx:
     url: {{ tpl .Values.config.dataexchangeUrl . }}
     {{- if .Values.config.dataexchangeAPIKey }}
     headers:


### PR DESCRIPTION
Addresses the warning we are getting since upgrading to FF `v0.13.0`:

```
firefly-0 firefly [2022-02-28T20:04:55.199Z]  WARN Your data exchange config uses the old plugin name 'https' - this plugin has been renamed to 'ffdx' pid=1
```