### PR TITLE
firefly-perfnode and firefly-perf Charts w/ Extra Sidecar Containers Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ local-values.yaml
 ### Helm ###
 # Chart dependencies
 **/charts/*.tgz
-**/local-values.yaml
+**/local-values*.yaml
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/charts/firefly-perf/.helmignore
+++ b/charts/firefly-perf/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/firefly-perf/Chart.yaml
+++ b/charts/firefly-perf/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: firefly-perf
+description: A Helm chart for running instances of ffperf as either a Job or StatefulSet with daemon mode enabled
+
+type: application
+version: 0.4.1
+appVersion: "0.0.1"

--- a/charts/firefly-perf/Chart.yaml
+++ b/charts/firefly-perf/Chart.yaml
@@ -1,7 +1,18 @@
 apiVersion: v2
 name: firefly-perf
-description: A Helm chart for running instances of ffperf as either a Job or StatefulSet with daemon mode enabled
+description: |
+  A Helm chart for running instances of ffperf as either a Job or StatefulSet with daemon mode enabled.
 
 type: application
-version: 0.4.1
+version: 0.1.0
 appVersion: "0.0.1"
+
+maintainers:
+  - name: hfuss
+    email: hayden.fuss@kaleido.io
+  - name: drewmarshburn
+    email: drew.marshburn@kaleido.io
+  - name: peterbroadhurst
+    email: peter.broadhurst@kaleido.io
+  - name: calbritt
+    email: cari.albritton@kaleido.io

--- a/charts/firefly-perf/templates/_helpers.tpl
+++ b/charts/firefly-perf/templates/_helpers.tpl
@@ -70,3 +70,9 @@ wsConfig:
 instances:
   {{ toYaml .Values.instances | nindent 2 }}
 {{- end }}
+
+{{- define "firefly-perf.instanceLengthSeconds" -}}
+{{/* input is in Golang Duration format i.e. "2h30m30s" but Helm doesn't have a direct way to convert to seconds */}}
+{{ $now := now }}
+{{ dateModify . $now | sub $now | add 60 }}
+{{- end }}

--- a/charts/firefly-perf/templates/_helpers.tpl
+++ b/charts/firefly-perf/templates/_helpers.tpl
@@ -60,3 +60,13 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "firefly-perf.instancesConfig" -}}
+stackJSONPath: /etc/firefly-perf-cli/stack.json
+
+wsConfig:
+  {{ toYaml .Values.wsConfig | nindent 2 }}
+
+instances:
+  {{ tpl .Values.instances . | nindent 2 }}
+{{- end }}

--- a/charts/firefly-perf/templates/_helpers.tpl
+++ b/charts/firefly-perf/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "firefly-perf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "firefly-perf.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "firefly-perf.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "firefly-perf.labels" -}}
+helm.sh/chart: {{ include "firefly-perf.chart" . }}
+{{ include "firefly-perf.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "firefly-perf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "firefly-perf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "firefly-perf.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "firefly-perf.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/firefly-perf/templates/_helpers.tpl
+++ b/charts/firefly-perf/templates/_helpers.tpl
@@ -68,5 +68,5 @@ wsConfig:
   {{ toYaml .Values.wsConfig | nindent 2 }}
 
 instances:
-  {{ tpl .Values.instances . | nindent 2 }}
+  {{ toYaml .Values.instances | nindent 2 }}
 {{- end }}

--- a/charts/firefly-perf/templates/job.yaml
+++ b/charts/firefly-perf/templates/job.yaml
@@ -1,0 +1,11 @@
+
+{{- if not .Values.daemonModeEnabled }}
+{{- range .Values.instances }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name:
+spec:
+  template:
+{{- end }}
+{{- end }}

--- a/charts/firefly-perf/templates/job.yaml
+++ b/charts/firefly-perf/templates/job.yaml
@@ -9,6 +9,73 @@ metadata:
     {{- include "firefly-perf.labels" . | nindent 4 }}
     hyperledger.io/firefly-perf-instance: {{ .name }}
 spec:
-  # TODO ...
+  # we add 60s to the provided instance length to ensure the Job will be around longer enough for the test to complete
+  activeDeadlineSeconds: {{ include "firefly-perf.instanceLengthSeconds" .length | add 60 }}
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      {{- with $root.Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "firefly-perf.selectorLabels" $root | nindent 8 }}
+    spec:
+      {{- with $root.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "firefly-perf.serviceAccountName" $root }}
+      securityContext:
+        {{- toYaml $root.Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ $root.Chart.Name }}
+          securityContext:
+            {{- toYaml $root.Values.securityContext | nindent 12 }}
+          image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag | default (printf "v%s" $root.Chart.AppVersion) }}"
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              export INSTANCE_IDX=${HOSTNAME##*-}
+
+              ffperf run --config /etc/firefly-perf-cli/instances.yaml --instance-name {{ .name }} --daemon
+          ports:
+            - name: http
+              containerPort: 5050
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: http
+          volumeMounts:
+            - mountPath: /etc/firefly-perf-cli
+              name: config
+          resources:
+            {{- toYaml $root.Values.resources | nindent 12 }}
+      {{- with $root.Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $root.Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $root.Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "firefly-perf.fullname" $root }}-config
 {{- end }}
 {{- end }}

--- a/charts/firefly-perf/templates/job.yaml
+++ b/charts/firefly-perf/templates/job.yaml
@@ -1,11 +1,14 @@
-
 {{- if not .Values.daemonModeEnabled }}
+{{- $root := . }}
 {{- range .Values.instances }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name:
+  name: {{ include "firefly-perf.fullname" $root }}-{{ .name }}
+  labels:
+    {{- include "firefly-perf.labels" . | nindent 4 }}
+    hyperledger.io/firefly-perf-instance: {{ .name }}
 spec:
-  template:
+  # TODO ...
 {{- end }}
 {{- end }}

--- a/charts/firefly-perf/templates/secret.yaml
+++ b/charts/firefly-perf/templates/secret.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "firefly-perf.fullname" . }}-config
-
+  labels:
+    {{- include "firefly-perf.labels" . | nindent 4 }}
 data:
-  stack.json: # TODO
-  instances.yaml: # TODO
+  stack.json: {{ tpl .Values.stack . | fromYaml | toJson | b64enc }}
+  instances.yaml: {{ include "firefly-perf.instancesConfig" . | b64enc }}

--- a/charts/firefly-perf/templates/secret.yaml
+++ b/charts/firefly-perf/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "firefly-perf.fullname" . }}-config
+
+data:
+  stack.json: # TODO
+  instances.yaml: # TODO

--- a/charts/firefly-perf/templates/service.yaml
+++ b/charts/firefly-perf/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonModeEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       name: http
   selector:
     {{- include "firefly-perf.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/firefly-perf/templates/service.yaml
+++ b/charts/firefly-perf/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "firefly-perf.fullname" . }}
+  labels:
+    {{- include "firefly-perf.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "firefly-perf.selectorLabels" . | nindent 4 }}

--- a/charts/firefly-perf/templates/serviceaccount.yaml
+++ b/charts/firefly-perf/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "firefly-perf.serviceAccountName" . }}
+  labels:
+    {{- include "firefly-perf.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/firefly-perf/templates/servicemonitor.yaml
+++ b/charts/firefly-perf/templates/servicemonitor.yaml
@@ -1,0 +1,7 @@
+{{- if and .Values.daemonModeEnabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name:
+
+{{- end }}

--- a/charts/firefly-perf/templates/servicemonitor.yaml
+++ b/charts/firefly-perf/templates/servicemonitor.yaml
@@ -2,6 +2,33 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name:
-
+  name: {{ include "firefly-perf.fullname" . }}
+  labels:
+    {{- include "firefly-perf.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.scrapeInterval }}
+      {{- if .Values.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
+  {{- if .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel | quote }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.namespaceSelector }}
+  namespaceSelector: {{ toYaml .Values.serviceMonitor.namespaceSelector | nindent 4 }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+      {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+    {{- include "firefly-perf.labels" . | nindent 6 }}
 {{- end }}

--- a/charts/firefly-perf/templates/statefulset.yaml
+++ b/charts/firefly-perf/templates/statefulset.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "firefly-perf.fullname" . }}
+  labels:
+    {{- include "firefly-perf.labels" . | nindent 4 }}
+spec:
+  replicas: {{ len .Values.instances }}
+  selector:
+    matchLabels:
+      {{- include "firefly-perf.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "firefly-perf.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "firefly-perf.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              export INSTANCE_IDX=${HOSTNAME##*-}
+
+              ffperf run --config /etc/firefly-perf-cli/instances.yaml --instance-idx ${INSTANCE_IDX} --daemon
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/firefly-perf/templates/statefulset.yaml
+++ b/charts/firefly-perf/templates/statefulset.yaml
@@ -10,6 +10,7 @@ spec:
   selector:
     matchLabels:
       {{- include "firefly-perf.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "firefly-perf.fullname" . }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -53,7 +54,7 @@ spec:
               path: /status
               port: http
           volumeMounts:
-            - mountPath: /etc/firefly-perf-node
+            - mountPath: /etc/firefly-perf-cli
               name: config
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/firefly-perf/templates/statefulset.yaml
+++ b/charts/firefly-perf/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh

--- a/charts/firefly-perf/templates/statefulset.yaml
+++ b/charts/firefly-perf/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonModeEnabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -41,16 +42,19 @@ spec:
               ffperf run --config /etc/firefly-perf-cli/instances.yaml --instance-idx ${INSTANCE_IDX} --daemon
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 5050
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /status
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /status
               port: http
+          volumeMounts:
+            - mountPath: /etc/firefly-perf-node
+              name: config
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -65,3 +69,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "firefly-perf.fullname" . }}-config
+{{- end }}

--- a/charts/firefly-perf/values.yaml
+++ b/charts/firefly-perf/values.yaml
@@ -1,0 +1,58 @@
+stack:
+  - # TODO
+
+wsConfig:
+  # TODO
+
+instances:
+  - # TODO
+
+daemonModeEnabled: false
+
+image:
+  repository: ghcr.io/hyperledger/firefly-perf-cli
+  pullPolicy: Always # TODO
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0.0.1-alpha" # TODO
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+resources: {}
+
+serviceMonitor:
+  enabled: false
+  # TODO

--- a/charts/firefly-perf/values.yaml
+++ b/charts/firefly-perf/values.yaml
@@ -23,8 +23,7 @@ wsConfig:
   maximumDelay: 30s
   initialConnectAttempts: 5
 
-instances: ""
-# instances: |
+instances: []
 #   - name: ff0-ff1-broadcast
 #     test: msg_broadcast
 #     length: 5m

--- a/charts/firefly-perf/values.yaml
+++ b/charts/firefly-perf/values.yaml
@@ -1,11 +1,38 @@
-stack:
-  - # TODO
+stack: ""
+#stack: |
+#  name: my-ff-network
+#  members:
+#    - id: "0"
+#      orgName: "org0"
+#      nodeName: "org0-firefly"
+#      fireflyHostname: "firefly.org0-firefly.svc.cluster.local"
+#      useHttps: false
+#      exposedFireflyPort: 3000
+#    - id: "1"
+#      orgName: "org1"
+#      nodeName: "org1-firefly"
+#      fireflyHostname: "firefly.org1-firefly.svc.cluster.local"
+#      useHttps: false
+#      exposedFireflyPort: 3000
 
 wsConfig:
-  # TODO
+  wsPath: /ws
+  readBufferSize: 16000
+  writeBufferSize: 16000
+  initialDelay: 250ms
+  maximumDelay: 30s
+  initialConnectAttempts: 5
 
-instances:
-  - # TODO
+instances: ""
+# instances: |
+#   - name: ff0-ff1-broadcast
+#     test: msg_broadcast
+#     length: 5m
+#     recipient: did:firefly:org/org_1
+#     recipientAddress: 0x912362b183362c8349d57a61e1c0c9183c08cff1
+#     workers: 10
+#     messageOptions:
+#       longMessage: true
 
 daemonModeEnabled: false
 
@@ -43,7 +70,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 5050
 
 nodeSelector: {}
 
@@ -55,4 +82,4 @@ resources: {}
 
 serviceMonitor:
   enabled: false
-  # TODO
+  scrapeInterval: 15s

--- a/charts/firefly-perf/values.yaml
+++ b/charts/firefly-perf/values.yaml
@@ -1,19 +1,19 @@
 stack: ""
-#stack: |
-#  name: my-ff-network
-#  members:
-#    - id: "0"
-#      orgName: "org0"
-#      nodeName: "org0-firefly"
-#      fireflyHostname: "firefly.org0-firefly.svc.cluster.local"
-#      useHttps: false
-#      exposedFireflyPort: 3000
-#    - id: "1"
-#      orgName: "org1"
-#      nodeName: "org1-firefly"
-#      fireflyHostname: "firefly.org1-firefly.svc.cluster.local"
-#      useHttps: false
-#      exposedFireflyPort: 3000
+# stack: |
+#   name: my-ff-network
+#   members:
+#     - id: "0"
+#       orgName: "org0"
+#       nodeName: "org0-firefly"
+#       fireflyHostname: "firefly.org0-firefly.svc.cluster.local"
+#       useHttps: false
+#       exposedFireflyPort: 3000
+#     - id: "1"
+#       orgName: "org1"
+#       nodeName: "org1-firefly"
+#       fireflyHostname: "firefly.org1-firefly.svc.cluster.local"
+#       useHttps: false
+#       exposedFireflyPort: 3000
 
 wsConfig:
   wsPath: /ws
@@ -37,9 +37,9 @@ daemonModeEnabled: false
 
 image:
   repository: ghcr.io/hyperledger/firefly-perf-cli
-  pullPolicy: Always # TODO
+  pullPolicy: Always  # TODO
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.0.1-alpha" # TODO
+  tag: "v0.0.1-alpha"  # TODO
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/firefly-perfnode/.gitignore
+++ b/charts/firefly-perfnode/.gitignore
@@ -1,0 +1,2 @@
+charts/firefly*.tgz
+Chart.lock

--- a/charts/firefly-perfnode/.helmignore
+++ b/charts/firefly-perfnode/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/firefly-perfnode/Chart.lock
+++ b/charts/firefly-perfnode/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: firefly
+  repository: file://../firefly
+  version: 0.3.3
+digest: sha256:a18edc67afc8e197dadfd3d30541221ca01ceb74ec74d081bdcaa7d7165d9598
+generated: "2022-03-16T23:22:11.411844-04:00"

--- a/charts/firefly-perfnode/Chart.lock
+++ b/charts/firefly-perfnode/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: firefly
-  repository: file://../firefly
-  version: 0.3.3
-digest: sha256:a18edc67afc8e197dadfd3d30541221ca01ceb74ec74d081bdcaa7d7165d9598
-generated: "2022-03-16T23:22:11.411844-04:00"

--- a/charts/firefly-perfnode/Chart.yaml
+++ b/charts/firefly-perfnode/Chart.yaml
@@ -10,5 +10,5 @@ appVersion: "0.13.1"
 
 dependencies:
   - name: firefly
-    version: 0.3.3
+    version: 0.4.1
     repository: file://../firefly

--- a/charts/firefly-perfnode/Chart.yaml
+++ b/charts/firefly-perfnode/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v2
 name: firefly-perfnode
-description: A Helm chart for deploying FireFly nodes configured for performance testing flows between members.
+description: |
+  A Helm chart for deploying FireFly nodes configured for performance testing flows between members.
 type: application
 version: 0.1.0
-appVersion: "0.13.1"
+appVersion: "0.14.0"
 
 maintainers:
   - name: hfuss
@@ -12,7 +13,8 @@ maintainers:
     email: drew.marshburn@kaleido.io
   - name: peterbroadhurst
     email: peter.broadhurst@kaleido.io
-
+  - name: calbritt
+    email: cari.albritton@kaleido.io
 
 dependencies:
   - name: firefly

--- a/charts/firefly-perfnode/Chart.yaml
+++ b/charts/firefly-perfnode/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: firefly-perfnode
+description: A Helm chart for Kubernetes
+
+type: application
+
+version: 0.1.0
+
+appVersion: "0.13.1"
+
+dependencies:
+  - name: firefly
+    version: 0.3.3
+    repository: file://../firefly

--- a/charts/firefly-perfnode/Chart.yaml
+++ b/charts/firefly-perfnode/Chart.yaml
@@ -1,12 +1,18 @@
 apiVersion: v2
 name: firefly-perfnode
-description: A Helm chart for Kubernetes
-
+description: A Helm chart for deploying FireFly nodes configured for performance testing flows between members.
 type: application
-
 version: 0.1.0
-
 appVersion: "0.13.1"
+
+maintainers:
+  - name: hfuss
+    email: hayden.fuss@kaleido.io
+  - name: drewmarshburn
+    email: drew.marshburn@kaleido.io
+  - name: peterbroadhurst
+    email: peter.broadhurst@kaleido.io
+
 
 dependencies:
   - name: firefly

--- a/charts/firefly-perfnode/templates/_helpers.tpl
+++ b/charts/firefly-perfnode/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "firefly-perfnode.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "firefly-perfnode.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "firefly-perfnode.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "firefly-perfnode.labels" -}}
+helm.sh/chart: {{ include "firefly-perfnode.chart" . }}
+{{ include "firefly-perfnode.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "firefly-perfnode.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "firefly-perfnode.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "firefly-perfnode.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "firefly-perfnode.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/firefly-perfnode/values.yaml
+++ b/charts/firefly-perfnode/values.yaml
@@ -1,0 +1,40 @@
+nameOverride: ""
+fullnameOverride: "firefly"
+
+firefly:
+  fullnameOverride: "firefly"
+  config:
+    # TODO check config
+    ipfsApiUrl: http://127.0.0.1:9001
+    ipfsGatewayUrl: http://127.0.0.1:9000
+    postgresUrl: psql://127.0.0.1:3206/firefly
+    postgresAutomigrate: true
+
+  core:
+    initContainers:
+      # TODO postgres / IPFS init
+      # IPFS needs UDP / broadcast discovery w/in K8s
+
+    extraContainers:
+      # TODO postgres / IPFS
+
+    volumeClaimTemplates:
+      # TODO postgres / IPFS
+      # storageClass and size will need to be configurable... possibly need this to be a template not list
+
+  dataexchange:
+    enabled: true
+
+    # TODO ... ?
+
+  ethconnect:
+    initContainers: []
+    # TODO geth init
+
+    extraContainers: []
+    # TODO geth
+
+    extraVolumeClaimTemplates: []
+    # TODO geth
+
+  # TODO which connectors? or leave it open ended?

--- a/charts/firefly-perfnode/values.yaml
+++ b/charts/firefly-perfnode/values.yaml
@@ -3,6 +3,10 @@ fullnameOverride: "firefly"
 
 firefly:
   fullnameOverride: "firefly"
+
+  ipfs:
+    bootstrap: ""
+
   config:
     ipfsApiUrl: http://127.0.0.1:5001
     ipfsGatewayUrl: http://127.0.0.1:8080
@@ -22,9 +26,9 @@ firefly:
       debugPort: 3030
       metricsPort: 3100
 
-    initContainers: []
+    initContainers: ""
 
-    extraContainers:
+    extraContainers: |
       - name: ipfs
         image: ipfs/go-ipfs:v0.12.1
         env:
@@ -37,6 +41,10 @@ firefly:
               965eee84178a43cc1af273c85905e4ec9e13fdfe309f08856109bec5b7b4756d
           - name: LIBP2P_FORCE_PNET
             value: "1"
+          {{- if .Values.ipfs.bootstraper }}
+          - name: IPFS_CONFIG_Bootstrap
+            value: "[\"{{ .Values.ipfs.bootstrap }}\"]"
+          {{- end }}
         volumeMounts:
           - mountPath: /export
             name: ipfs
@@ -81,7 +89,7 @@ firefly:
           timeoutSeconds: 3
           periodSeconds: 5
 
-    volumeClaimTemplates:
+    volumeClaimTemplates: |
       - metadata:
           name: ipfs
         spec:
@@ -114,13 +122,13 @@ firefly:
     enabled: true
 
   ethconnect:
-    initContainers: []
+    initContainers: ""
     # TODO geth init
 
-    extraContainers: []
+    extraContainers: ""
     # TODO geth
 
-    extraVolumeClaimTemplates: []
+    extraVolumeClaimTemplates: ""
     # TODO geth
 
   # TODO which connectors? or leave it open ended?

--- a/charts/firefly-perfnode/values.yaml
+++ b/charts/firefly-perfnode/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: "firefly"
 firefly:
   fullnameOverride: "firefly"
   config:
-    ipfsApiUrl: http://127.0.0.1:50001
+    ipfsApiUrl: http://127.0.0.1:5001
     ipfsGatewayUrl: http://127.0.0.1:8080
     postgresUrl: postgres://postgres:f1refly@127.0.0.1:5432?sslmode=disable
     postgresAutomigrate: true
@@ -15,6 +15,12 @@ firefly:
         enabled: false
       registration:
         enabled: true
+
+    service:
+      httpPort: 3000
+      adminPort: 3001
+      debugPort: 3030
+      metricsPort: 3100
 
     initContainers: []
 
@@ -34,10 +40,10 @@ firefly:
         volumeMounts:
           - mountPath: /export
             name: ipfs
-            subPath: /export
+            subPath: export
           - mountPath: /data/ipfs
             name: ipfs
-            subPath: /data
+            subPath: data
         ports:
           - containerPort: 4001
             protocol: TCP
@@ -59,7 +65,7 @@ firefly:
           - name: PGDATA
             value: /var/lib/postgresql/data/pgdata
         volumeMounts:
-          - mountPath: /var/lib/postgresql/data/pgdata
+          - mountPath: /var/lib/postgresql/data
             name: postgres
         ports:
           - containerPort: 5432
@@ -81,7 +87,7 @@ firefly:
         spec:
           accessModes:
             - ReadWriteOnce
-          storageClassName: io1
+          storageClassName: io2
           resources:
             requests:
               storage: 10Gi
@@ -90,12 +96,21 @@ firefly:
         spec:
           accessModes:
             - ReadWriteOnce
-          storageClassName: io1
+          storageClassName: io2
           resources:
             requests:
               storage: 10Gi
 
   dataexchange:
+    enabled: true
+
+    persistentVolumes:
+      blobs:
+        storageClass: io2
+      peers:
+        storageClass: gp3
+
+  erc1155:
     enabled: true
 
   ethconnect:

--- a/charts/firefly-perfnode/values.yaml
+++ b/charts/firefly-perfnode/values.yaml
@@ -41,10 +41,22 @@ firefly:
               965eee84178a43cc1af273c85905e4ec9e13fdfe309f08856109bec5b7b4756d
           - name: LIBP2P_FORCE_PNET
             value: "1"
-          {{- if .Values.ipfs.bootstraper }}
-          - name: IPFS_CONFIG_Bootstrap
-            value: "[\"{{ .Values.ipfs.bootstrap }}\"]"
-          {{- end }}
+        {{- if .Values.ipfs.bootstrap }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - 'sh'
+                - '-c'
+                - |
+                  until ipfs swarm addrs; do
+                    echo "waiting for IPFS to come up..."
+                    sleep 5
+                  done
+                  sleep 5
+                  ipfs swarm peering add {{ .Values.ipfs.bootstrap }}
+                  ipfs swarm connect {{ .Values.ipfs.bootstrap }}
+        {{- end }}
         volumeMounts:
           - mountPath: /export
             name: ipfs
@@ -114,6 +126,7 @@ firefly:
 
     persistentVolumes:
       blobs:
+        size: 4Gi
         storageClass: io2
       peers:
         storageClass: gp3

--- a/charts/firefly-perfnode/values.yaml
+++ b/charts/firefly-perfnode/values.yaml
@@ -4,28 +4,99 @@ fullnameOverride: "firefly"
 firefly:
   fullnameOverride: "firefly"
   config:
-    # TODO check config
-    ipfsApiUrl: http://127.0.0.1:9001
-    ipfsGatewayUrl: http://127.0.0.1:9000
-    postgresUrl: psql://127.0.0.1:3206/firefly
+    ipfsApiUrl: http://127.0.0.1:50001
+    ipfsGatewayUrl: http://127.0.0.1:8080
+    postgresUrl: postgres://postgres:f1refly@127.0.0.1:5432?sslmode=disable
     postgresAutomigrate: true
 
   core:
-    initContainers:
-      # TODO postgres / IPFS init
-      # IPFS needs UDP / broadcast discovery w/in K8s
+    jobs:
+      postgresMigrations:
+        enabled: false
+      registration:
+        enabled: true
+
+    initContainers: []
 
     extraContainers:
-      # TODO postgres / IPFS
+      - name: ipfs
+        image: ipfs/go-ipfs:v0.12.1
+        env:
+          # bc this is hardcoded, multiple firefly _networks_ cannot be installed on the same k8s cluster via ff-perfnode
+          # w/o running the risk of the IPFS nodes across the networks joining each other
+          - name: IPFS_SWARM_KEY
+            value: |-
+              /key/swarm/psk/1.0.0/
+              /base16/
+              965eee84178a43cc1af273c85905e4ec9e13fdfe309f08856109bec5b7b4756d
+          - name: LIBP2P_FORCE_PNET
+            value: "1"
+        volumeMounts:
+          - mountPath: /export
+            name: ipfs
+            subPath: /export
+          - mountPath: /data/ipfs
+            name: ipfs
+            subPath: /data
+        ports:
+          - containerPort: 4001
+            protocol: TCP
+            name: p2p
+          - containerPort: 4001
+            protocol: UDP
+            name: p2p-udp
+          - containerPort: 5001
+            protocol: TCP
+            name: api
+          - containerPort: 8080
+            protocol: TCP
+            name: gateway
+      - name: postgres
+        image: postgres:14.2-alpine3.15
+        env:
+          - name: POSTGRES_PASSWORD
+            value: "f1refly"
+          - name: PGDATA
+            value: /var/lib/postgresql/data/pgdata
+        volumeMounts:
+          - mountPath: /var/lib/postgresql/data/pgdata
+            name: postgres
+        ports:
+          - containerPort: 5432
+            protocol: TCP
+            name: psql
+        livenessProbe:
+          exec:
+            command:
+              - pg_isready
+              - -U
+              - postgres
+          failureThreshold: 12
+          timeoutSeconds: 3
+          periodSeconds: 5
 
     volumeClaimTemplates:
-      # TODO postgres / IPFS
-      # storageClass and size will need to be configurable... possibly need this to be a template not list
+      - metadata:
+          name: ipfs
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          storageClassName: io1
+          resources:
+            requests:
+              storage: 10Gi
+      - metadata:
+          name: postgres
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          storageClassName: io1
+          resources:
+            requests:
+              storage: 10Gi
 
   dataexchange:
     enabled: true
-
-    # TODO ... ?
 
   ethconnect:
     initContainers: []
@@ -38,3 +109,4 @@ firefly:
     # TODO geth
 
   # TODO which connectors? or leave it open ended?
+  # TODO ERC1155

--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -19,7 +19,7 @@ name: firefly
 description: A Helm chart for deploying FireFly and FireFly HTTPS Dataexchange onto Kubernetes.
 type: application
 appVersion: "0.14.0"
-version: "0.4.0"
+version: "0.4.1"
 
 maintainers:
   - name: hfuss

--- a/charts/firefly/templates/core/statefulset.yaml
+++ b/charts/firefly/templates/core/statefulset.yaml
@@ -46,6 +46,10 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.core.podSecurityContext | nindent 8 }}
+      {{- with .Values.core.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: firefly
           securityContext:
@@ -95,6 +99,9 @@ spec:
               name: firefly-config
           resources:
             {{- toYaml .Values.core.resources | nindent 12 }}
+      {{- with .Values.core.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.core.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -111,3 +118,7 @@ spec:
         - name: firefly-config
           secret:
             secretName: {{ include "firefly.fullname" . }}-config
+  {{- with .Values.core.volumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/firefly/templates/core/statefulset.yaml
+++ b/charts/firefly/templates/core/statefulset.yaml
@@ -46,9 +46,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.core.podSecurityContext | nindent 8 }}
-      {{- with .Values.core.initContainers }}
+      {{- if .Values.core.initContainers }}
       initContainers:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl .Values.core.initContainers . | nindent 8 }}
       {{- end }}
       containers:
         - name: firefly
@@ -99,8 +99,8 @@ spec:
               name: firefly-config
           resources:
             {{- toYaml .Values.core.resources | nindent 12 }}
-      {{- with .Values.core.extraContainers }}
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.core.extraContainers }}
+        {{- tpl .Values.core.extraContainers . | nindent 8 }}
       {{- end }}
       {{- with .Values.core.nodeSelector }}
       nodeSelector:
@@ -118,7 +118,7 @@ spec:
         - name: firefly-config
           secret:
             secretName: {{ include "firefly.fullname" . }}-config
-  {{- with .Values.core.volumeClaimTemplates }}
+  {{- if .Values.core.volumeClaimTemplates }}
   volumeClaimTemplates:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl .Values.core.volumeClaimTemplates . | nindent 4 }}
   {{- end }}

--- a/charts/firefly/templates/ethconnect/statefulset.yaml
+++ b/charts/firefly/templates/ethconnect/statefulset.yaml
@@ -47,6 +47,10 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.ethconnect.podSecurityContext | nindent 8 }}
+      {{- with .Values.ethconnect.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: ethconnect
           securityContext:
@@ -89,6 +93,9 @@ spec:
             - mountPath: /etc/ethconnect/config.yaml
               name: config
               subPath: config.yaml
+      {{- with .Values.core.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.ethconnect.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -121,4 +128,7 @@ spec:
           requests:
             storage: {{ .size }}
       {{- end }}
+  {{- with .Values.ethconnect.extraVolumeClaimTemplates }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/firefly/templates/ethconnect/statefulset.yaml
+++ b/charts/firefly/templates/ethconnect/statefulset.yaml
@@ -47,9 +47,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.ethconnect.podSecurityContext | nindent 8 }}
-      {{- with .Values.ethconnect.initContainers }}
+      {{- if .Values.ethconnect.initContainers }}
       initContainers:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl .Values.ethconnect.initContainers . | nindent 8 }}
       {{- end }}
       containers:
         - name: ethconnect
@@ -93,8 +93,8 @@ spec:
             - mountPath: /etc/ethconnect/config.yaml
               name: config
               subPath: config.yaml
-      {{- with .Values.core.extraContainers }}
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.ethconnect.extraContainers }}
+        {{- tpl .Values.ethconnect.extraContainers . | nindent 8 }}
       {{- end }}
       {{- with .Values.ethconnect.nodeSelector }}
       nodeSelector:
@@ -128,7 +128,7 @@ spec:
           requests:
             storage: {{ .size }}
       {{- end }}
-  {{- with .Values.ethconnect.extraVolumeClaimTemplates }}
-    {{- toYaml . | nindent 4 }}
+  {{- if .Values.ethconnect.extraVolumeClaimTemplates }}
+    {{- tpl .Values.ethconnect.extraVolumeClaimTemplates . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/firefly/values.yaml
+++ b/charts/firefly/values.yaml
@@ -181,6 +181,10 @@ core:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+  initContainers: []
+  extraContainers: []
+  volumeClaimTemplates: []
+
   service:
     type: ClusterIP
     httpPort: 5000
@@ -518,6 +522,10 @@ ethconnect:
   service:
     type: ClusterIP
     apiPort: 5102
+
+  initContainers: []
+  extraContainers: []
+  extraVolumeClaimTemplates: []
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/firefly/values.yaml
+++ b/charts/firefly/values.yaml
@@ -181,9 +181,9 @@ core:
     # runAsNonRoot: true
     # runAsUser: 1000
 
-  initContainers: []
-  extraContainers: []
-  volumeClaimTemplates: []
+  initContainers: ""
+  extraContainers: ""
+  volumeClaimTemplates: ""
 
   service:
     type: ClusterIP
@@ -523,9 +523,9 @@ ethconnect:
     type: ClusterIP
     apiPort: 5102
 
-  initContainers: []
-  extraContainers: []
-  extraVolumeClaimTemplates: []
+  initContainers: ""
+  extraContainers: ""
+  extraVolumeClaimTemplates: ""
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/manifests/storageclasses.yaml
+++ b/manifests/storageclasses.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+allowVolumeExpansion: true
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: io2
+allowVolumeExpansion: true
+provisioner: ebs.csi.aws.com
+parameters:
+  type: io2
+  iopsPerGB: "200"
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
Adds a new `firefly-perfnode` chart that comes with preconfigured IPFS and PostgreSQL sidecar containers (similar to docker compose setup from https://github.com/hyperledger/firefly-cli for perf testing as part of https://github.com/hyperledger/firefly/issues/519

Uses https://github.com/hyperledger/firefly-perf-cli/pull/26 with a new `firefly-perf` chart to deploy multiple `ffperf` instances within a `StatefulSet` for load and performance testing a FireFly network that is either deployed with `firefly` or the `firefly-perfnode` chart.