### PR TITLE
[o11y] Add default Prometheus Rule to alert off Firefly core metrics

### DIFF
--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -19,7 +19,7 @@ name: firefly
 description: A Helm chart for deploying FireFly and FireFly HTTPS Dataexchange onto Kubernetes.
 type: application
 appVersion: "1.0.4"
-version: "0.5.5"
+version: "0.5.6"
 
 maintainers:
   - name: hfuss

--- a/charts/firefly/templates/_helpers.tpl
+++ b/charts/firefly/templates/_helpers.tpl
@@ -200,6 +200,59 @@ Config helpers
 {{- printf "http://%s.%s.svc:%d" (include "firefly.fullname" .) .Release.Namespace (.Values.core.service.adminPort | int64) }}
 {{- end }}
 
+{{- define "firefly.serviceMonitorJobName" -}}
+{{- printf "serviceMonitor/%s/%s/0" .Release.Namespace (include "firefly.fullname" .) }}
+{{- end }}
+
+{{- define "firefly.defaultPrometheusRules" -}}
+- alert: FireflyTargetDown
+  {{- if .Values.core.metrics.serviceMonitor.jobLabel }}
+  expr: up{job={{ .Values.core.metrics.serviceMonitor.jobLabel | quote}}} == 0
+  {{- else }}
+  expr: up{job={{include "firefly.serviceMonitorJobName" . | quote}}} == 0
+  {{- end }}
+  labels:
+    severity: {{ .Values.core.metrics.prometheusRule.criticalSeverity }}
+  annotations:
+    description: Firefly Metrics Target down and is not exporting metrics
+    summary: Firefly Metric Target down
+- alert: FireflyBroadcastsRejected
+  expr: 'increase(ff_broadcast_rejected_total[5m]) > 0'
+  labels:
+    severity: {{ .Values.core.metrics.prometheusRule.warningSeverity }}
+  annotations:
+    summary: Firefly Broadcasts Rejected
+    description: Firefly Broadcasts have failed at least once in the last 5 min
+- alert: FireflyBurnsRejected
+  expr: 'increase(ff_burn_rejected_total [5m]) > 0'
+  labels:
+    severity: {{ .Values.core.metrics.prometheusRule.warningSeverity }}
+  annotations:
+    summary: Firefly Burns Rejected
+    description: Firefly Burns have failed at least once in the last 5 min
+- alert: FireflyMintsRejected
+  expr: 'increase(ff_mint_rejected_total [5m]) > 0'
+  labels:
+    severity: {{ .Values.core.metrics.prometheusRule.warningSeverity }}
+  annotations:
+    summary: Firefly Mints Rejected
+    description: Firefly Mints have failed at least once in the last 5 min
+- alert: FireflyPrivateMessagesRejected
+  expr: 'increase(ff_private_msg_rejected_total [5m]) > 0'
+  labels:
+    severity: {{ .Values.core.metrics.prometheusRule.warningSeverity }}
+  annotations:
+    summary: Firefly Private Messages Rejected
+    description: Firefly Private Messages have failed at least once in the last 5 min
+- alert: FireflyTransfersRejected
+  expr: 'increase(ff_transfer_rejected_total [5m]) > 0'
+  labels:
+    severity: {{ .Values.core.metrics.prometheusRule.warningSeverity }}
+  annotations:
+    summary: Firefly Transfers Rejected
+    description: Firefly Transfers have failed at least once in the last 5 min
+{{- end }}
+
 {{- define "firefly.coreConfig" -}}
 {{- if .Values.config.debugEnabled }}
 log:

--- a/charts/firefly/templates/_helpers.tpl
+++ b/charts/firefly/templates/_helpers.tpl
@@ -207,9 +207,9 @@ Config helpers
 {{- define "firefly.defaultPrometheusRules" -}}
 - alert: FireflyTargetDown
   {{- if .Values.core.metrics.serviceMonitor.jobLabel }}
-  expr: up{job={{ .Values.core.metrics.serviceMonitor.jobLabel | quote}}} == 0
+  expr: up{job={{ .Values.core.metrics.serviceMonitor.jobLabel | quote }} } == 0
   {{- else }}
-  expr: up{job={{include "firefly.serviceMonitorJobName" . | quote}}} == 0
+  expr: up{job={{include "firefly.serviceMonitorJobName" . | quote }} } == 0
   {{- end }}
   labels:
     severity: {{ .Values.core.metrics.prometheusRule.criticalSeverity }}

--- a/charts/firefly/templates/core/prometheusrule.yaml
+++ b/charts/firefly/templates/core/prometheusrule.yaml
@@ -1,0 +1,76 @@
+{{/*
+  Copyright © 2022 Kaleido, Inc.
+
+  SPDX-License-Identifier: Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://swww.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if and .Values.core.metrics.alertRule.enabled .Values.config.metricsEnabled }}
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+# WARNING: prometheus-operator is not installed but alertRule has been enabled, this will fail. Please install
+#          prometheus-operator to resolve this.
+{{- end }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "firefly.fullname" . }}
+  labels:
+  {{- include "firefly.coreLabels" . | nindent 4 }}
+spec:
+  groups:
+    - name: {{ include "firefly.fullname" . }}
+      rules:
+        - alert: {{ include "firefly.fullname" . }}TargetDown
+          expr: 'up{job="serviceMonitor/{{ .Release.Namespace }}/{{ include "firefly.fullname" . }}/0"} == 0'
+          labels:
+            severity: {{ .Values.core.metrics.alertRule.severity }}
+          annotations:
+            description: Firefly Metrics Target down and is not exporting metrics
+            summary: Firefly Metric Target down
+        - alert: {{ include "firefly.fullname" . }}BroadcastsRejected
+          expr: 'increase(ff_broadcast_rejected_total[5m]) > 0'
+          labels:
+            severity: {{ .Values.core.metrics.alertRule.severity }}
+          annotations:
+            summary: Firefly Broadcasts Rejected
+            description: Firefly Broadcasts have failed at least once in the last 5 min
+        - alert: {{ include "firefly.fullname" . }}BurnsRejected
+          expr: 'increase(ff_burn_rejected_total [5m]) > 0'
+          labels:
+            severity: {{ .Values.core.metrics.alertRule.severity }}
+          annotations:
+            summary: Firefly Burns Rejected
+            description: Firefly Burns have failed at least once in the last 5 min
+        - alert: {{ include "firefly.fullname" . }}MintsRejected
+          expr: 'increase(ff_mint_rejected_total [5m]) > 0'
+          labels:
+            severity: {{ .Values.core.metrics.alertRule.severity }}
+          annotations:
+            summary: Firefly Mints Rejected
+            description: Firefly Mints have failed at least once in the last 5 min
+        - alert: {{ include "firefly.fullname" . }}PrivateMessagesRejected
+          expr: 'increase(ff_private_msg_rejected_total [5m]) > 0'
+          labels:
+            severity: {{ .Values.core.metrics.alertRule.severity }}
+          annotations:
+            summary: Firefly Private Messages Rejected
+            description: Firefly Private Messages have failed at least once in the last 5 min
+        - alert: {{ include "firefly.fullname" . }}TransfersRejected
+          expr: 'increase(ff_transfer_rejected_total [5m]) > 0'
+          labels:
+            severity: {{ .Values.core.metrics.alertRule.severity }}
+          annotations:
+            summary: Firefly Transfers Rejected
+            description: Firefly Transfers have failed at least once in the last 5 min
+{{- end }}

--- a/charts/firefly/templates/core/prometheusrule.yaml
+++ b/charts/firefly/templates/core/prometheusrule.yaml
@@ -31,8 +31,8 @@ spec:
   groups:
     - name: {{ include "firefly.fullname" . }}
       rules: |
-        {{- include "firefly.defaultPrometheusRules" . | nindent 8 }}
+        {{- include "firefly.defaultPrometheusRules" . | nindent 4 }}
         {{- if .Values.core.metrics.prometheusRule.rules }}
-        {{- tpl .Values.core.metrics.prometheusRule.rules . | nindent 8 }}
+        {{- tpl .Values.core.metrics.prometheusRule.rules . | nindent 4 }}
         {{- end }}
 {{- end }}

--- a/charts/firefly/templates/core/prometheusrule.yaml
+++ b/charts/firefly/templates/core/prometheusrule.yaml
@@ -16,7 +16,7 @@
   limitations under the License.
 */}}
 
-{{- if and .Values.core.metrics.prometheusRule.enabled .Values.config.metricsEnabled }}
+{{- if and .Values.core.metrics.prometheusRule.enabled .Values.config.metricsEnabled .Values.core.metrics.serviceMonitor.enabled}}
 {{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 # WARNING: prometheus-operator is not installed but prometheusRule has been enabled, this will fail. Please install
 #          prometheus-operator to resolve this.

--- a/charts/firefly/templates/core/prometheusrule.yaml
+++ b/charts/firefly/templates/core/prometheusrule.yaml
@@ -32,7 +32,11 @@ spec:
     - name: {{ include "firefly.fullname" . }}
       rules:
         - alert: {{ include "firefly.fullname" . }}TargetDown
+          {{- if .Values.core.metrics.serviceMonitor.jobLabel }}
+          expr: 'up{job="{{.Values.core.metrics.serviceMonitor.jobLabel}}"} == 0'
+          {{- else if }}
           expr: 'up{job="serviceMonitor/{{ .Release.Namespace }}/{{ include "firefly.fullname" . }}/0"} == 0'
+          {{- end }}
           labels:
             severity: {{ .Values.core.metrics.alertRule.severity }}
           annotations:

--- a/charts/firefly/templates/core/prometheusrule.yaml
+++ b/charts/firefly/templates/core/prometheusrule.yaml
@@ -16,9 +16,9 @@
   limitations under the License.
 */}}
 
-{{- if and .Values.core.metrics.alertRule.enabled .Values.config.metricsEnabled }}
+{{- if and .Values.core.metrics.prometheusRule.enabled .Values.config.metricsEnabled }}
 {{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
-# WARNING: prometheus-operator is not installed but alertRule has been enabled, this will fail. Please install
+# WARNING: prometheus-operator is not installed but prometheusRule has been enabled, this will fail. Please install
 #          prometheus-operator to resolve this.
 {{- end }}
 apiVersion: monitoring.coreos.com/v1
@@ -30,51 +30,9 @@ metadata:
 spec:
   groups:
     - name: {{ include "firefly.fullname" . }}
-      rules:
-        - alert: {{ include "firefly.fullname" . }}TargetDown
-          {{- if .Values.core.metrics.serviceMonitor.jobLabel }}
-          expr: 'up{job="{{.Values.core.metrics.serviceMonitor.jobLabel}}"} == 0'
-          {{- else }}
-          expr: 'up{job="serviceMonitor/{{ .Release.Namespace }}/{{ include "firefly.fullname" . }}/0"} == 0'
-          {{- end }}
-          labels:
-            severity: {{ .Values.core.metrics.alertRule.severity }}
-          annotations:
-            description: Firefly Metrics Target down and is not exporting metrics
-            summary: Firefly Metric Target down
-        - alert: {{ include "firefly.fullname" . }}BroadcastsRejected
-          expr: 'increase(ff_broadcast_rejected_total[5m]) > 0'
-          labels:
-            severity: {{ .Values.core.metrics.alertRule.severity }}
-          annotations:
-            summary: Firefly Broadcasts Rejected
-            description: Firefly Broadcasts have failed at least once in the last 5 min
-        - alert: {{ include "firefly.fullname" . }}BurnsRejected
-          expr: 'increase(ff_burn_rejected_total [5m]) > 0'
-          labels:
-            severity: {{ .Values.core.metrics.alertRule.severity }}
-          annotations:
-            summary: Firefly Burns Rejected
-            description: Firefly Burns have failed at least once in the last 5 min
-        - alert: {{ include "firefly.fullname" . }}MintsRejected
-          expr: 'increase(ff_mint_rejected_total [5m]) > 0'
-          labels:
-            severity: {{ .Values.core.metrics.alertRule.severity }}
-          annotations:
-            summary: Firefly Mints Rejected
-            description: Firefly Mints have failed at least once in the last 5 min
-        - alert: {{ include "firefly.fullname" . }}PrivateMessagesRejected
-          expr: 'increase(ff_private_msg_rejected_total [5m]) > 0'
-          labels:
-            severity: {{ .Values.core.metrics.alertRule.severity }}
-          annotations:
-            summary: Firefly Private Messages Rejected
-            description: Firefly Private Messages have failed at least once in the last 5 min
-        - alert: {{ include "firefly.fullname" . }}TransfersRejected
-          expr: 'increase(ff_transfer_rejected_total [5m]) > 0'
-          labels:
-            severity: {{ .Values.core.metrics.alertRule.severity }}
-          annotations:
-            summary: Firefly Transfers Rejected
-            description: Firefly Transfers have failed at least once in the last 5 min
+      rules: |
+        {{- include "firefly.defaultPrometheusRules" . | nindent 8 }}
+        {{- if .Values.core.metrics.prometheusRule.rules }}
+        {{- tpl .Values.core.metrics.prometheusRule.rules . | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/charts/firefly/templates/core/prometheusrule.yaml
+++ b/charts/firefly/templates/core/prometheusrule.yaml
@@ -34,7 +34,7 @@ spec:
         - alert: {{ include "firefly.fullname" . }}TargetDown
           {{- if .Values.core.metrics.serviceMonitor.jobLabel }}
           expr: 'up{job="{{.Values.core.metrics.serviceMonitor.jobLabel}}"} == 0'
-          {{- else if }}
+          {{- else }}
           expr: 'up{job="serviceMonitor/{{ .Release.Namespace }}/{{ include "firefly.fullname" . }}/0"} == 0'
           {{- end }}
           labels:

--- a/charts/firefly/values.yaml
+++ b/charts/firefly/values.yaml
@@ -207,6 +207,9 @@ core:
     serviceMonitor:
       enabled: false
       scrapeInterval: 10s
+    alertRule:
+      enabled: false
+      severity: ""
 
   # NOTE: The Ingress will only expose the HTTP API and never the Admin or Debug APIs
   ingress:

--- a/charts/firefly/values.yaml
+++ b/charts/firefly/values.yaml
@@ -207,9 +207,11 @@ core:
     serviceMonitor:
       enabled: false
       scrapeInterval: 10s
-    alertRule:
+    prometheusRule:
       enabled: false
-      severity: ""
+      criticalSeverity: "critical"
+      warningSeverity: "warning"
+      rules: []
 
   # NOTE: The Ingress will only expose the HTTP API and never the Admin or Debug APIs
   ingress:


### PR DESCRIPTION
Alerts if the firefly core target is not up.

Alerts if any actions below get rejected:
- mints
- transfers
- burns
- private messages
- broadcasts 

Resolving this issue - https://github.com/hyperledger/firefly-helm-charts/issues/47