### PR TITLE
fix service name for sandbox ingress

### DIFF
--- a/charts/firefly/templates/sandbox/ingress.yaml
+++ b/charts/firefly/templates/sandbox/ingress.yaml
@@ -68,7 +68,7 @@ spec:
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ $fullName }}-sandbox
               servicePort: {{ $svcPort }}
               {{- end }}
     {{- end }}

--- a/charts/firefly/templates/sandbox/ingress.yaml
+++ b/charts/firefly/templates/sandbox/ingress.yaml
@@ -64,7 +64,7 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-sandbox
                 port:
                   number: {{ $svcPort }}
               {{- else }}


### PR DESCRIPTION
When Ingress is enabled for sandbox, it fails as it cannot find the correct service name. This fixes that.