### PR TITLE
Add explicit github actions permissions

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -55,6 +55,9 @@ jobs:
     needs: test
     if: github.event_name == 'push' || github.event_name == 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Fix 403 Forbidden on push to ghcr https://github.com/hyperledger/firefly-helm-charts/actions/runs/10368345659/job/28701800460

It seems recently we had the same issue on tezos connector https://github.com/hyperledger/firefly-tezosconnect/actions/runs/10303175771/job/28518553850

> ERROR: failed to solve: failed to push ghcr.io/hyperledger/firefly-tezosconnect:v0.2.5-20240808-47: unexpected status from POST request to https://ghcr.io/v2/hyperledger/firefly-tezosconnect/blobs/uploads/: 403 Forbidden

Adding `packages: write` helped us since this permission allows the workflow to write to the repository’s package registry.  So might help here as well 

