### PR TITLE
docs: Updates to charts to signify convention for version updates

### DIFF
--- a/charts/firefly-evmconnect/Chart.yaml
+++ b/charts/firefly-evmconnect/Chart.yaml
@@ -5,6 +5,11 @@ description: |
   Requires a running instance of FireFly and a persistent volume for managing its
   transaction state.
 type: application
+
+# Generally we follow this practice for updates to the chart version number:
+#  - Significant changes to the structure or purpose of the chart (major version update)
+#  - FireFly EVM Connect major release (minor version update)
+#  - Smaller release and updates (patch version updates)
 version: 0.8.0
 appVersion: "v1.3.18"
 

--- a/charts/firefly-signer/Chart.yaml
+++ b/charts/firefly-signer/Chart.yaml
@@ -3,6 +3,11 @@ name: firefly-signer
 description: |
   A Helm chart for deploying the FireFly Signer microservice to Kubernetes
 type: application
+
+# Generally we follow this practice for updates to the chart version number:
+#  - Significant changes to the structure or purpose of the chart (major version update)
+#  - FireFly Signer major release (minor version update)
+#  - Smaller release and updates (patch version updates)
 version: 0.8.0
 appVersion: "1.1.17"
 

--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -30,7 +30,7 @@ appVersion: "1.3.2"
 #  - Smaller release and updates (patch version updates)
 #
 # For example, a release of FireFly like 1.3.1 -> 1.3.2 would correlate to a patch version
-# update, whereas a change like 1.2.2 -> 1.3.0 would be a major version update.
+# update, whereas a change like 1.2.2 -> 1.3.0 would be a minor version update.
 version: "0.9.0"
 
 maintainers:

--- a/charts/firefly/Chart.yaml
+++ b/charts/firefly/Chart.yaml
@@ -21,7 +21,16 @@ description: |
   By default allows the user to deploy FireFly with a single multi-party namespace, with the
   ability to template additional multi-party or gateway namespaces.
 type: application
+
 appVersion: "1.3.2"
+
+# Generally we follow this practice for updates to the chart version number:
+#  - Significant changes to the structure or purpose of the chart (major version update)
+#  - FireFly major release (minor version update)
+#  - Smaller release and updates (patch version updates)
+#
+# For example, a release of FireFly like 1.3.1 -> 1.3.2 would correlate to a patch version
+# update, whereas a change like 1.2.2 -> 1.3.0 would be a major version update.
 version: "0.9.0"
 
 maintainers:


### PR DESCRIPTION
ref: https://github.com/hyperledger/firefly-helm-charts/pull/81

The previous PR _probably_ on reflection have been a patch version update to the charts, but I realised we don't have any documentation on what kind of update correlates to what kind of version update, so I've taken a stab here as a strawman.